### PR TITLE
Add financial P/E analysis module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,39 @@
-# AI-Driven Application Generator
+# Financial P/E Analysis Tool
 
-This project is an AI-driven application generator designed to break down objectives into subtasks and generate code files based on user input. It leverages language models to automate the process, ensuring efficient and accurate code generation. The project employs a master orchestrator to define tasks and subagents to execute them, creating a seamless workflow for complex programming tasks.
-
-## Table of Contents
-
-- [Overview](#overview)
-- [Features](#features)
-- [How It Works](#how-it-works)
-- [Setup](#setup)
-- [Usage](#usage)
-- [Folder Structure](#folder-structure)
-- [Contributing](#contributing)
-- [License](#license)
+This repository provides simple utilities for evaluating whether a stock is potentially undervalued based on its price-to-earnings (P/E) ratio.  Stock prices and earnings information are fetched from the Alpha Vantage public API.
 
 ## Overview
 
-The AI-Driven Application Generator automates the process of breaking down complex programming tasks into smaller, manageable subtasks and generating the corresponding code files. This project ensures that all generated code is saved reliably and that the overall process is efficient.
-
-## Features
-
-- **Task Orchestration**: The master orchestrator breaks down complex objectives into smaller subtasks.
-- **Subtask Delegation**: Subagents handle the execution of each subtask.
-- **Error Handling**: Detailed error handling and logging for robust execution.
-- **File Management**: Reliable file handling and project structure creation.
-- **Checkpointing**: Saves progress to prevent data loss in case of interruptions.
-
-## How It Works
-
-The AI-Driven Application Generator uses two main components: the master orchestrator and the subagents.
-
-### Master Orchestrator
-
-The master orchestrator is responsible for:
-
-1. **Receiving Objectives**: It takes user input specifying the objective.
-2. **Breaking Down Tasks**: It divides the objective into smaller, manageable subtasks.
-3. **Reviewing Outputs**: It reviews the outputs from subagents to ensure they meet the specified requirements.
-
-### Subagents
-
-Subagents are responsible for:
-
-1. **Executing Subtasks**: They perform the tasks defined by the master orchestrator.
-2. **Generating Code**: They create the necessary code files based on the task requirements.
-3. **Handling Errors**: They provide feedback on any issues encountered during execution.
-
-### Workflow
-
-1. **Initialization**: The user inputs an objective and any associated files.
-2. **Task Breakdown**: The orchestrator breaks the objective into subtasks.
-3. **Subtask Execution**: Subagents execute the subtasks and generate code.
-4. **Review and Refine**: The orchestrator reviews the outputs and refines them if necessary.
-5. **File Creation**: The project structure and files are created and saved.
+1. **Fetch market data** – Current closing prices and EPS data are retrieved for any ticker symbol.
+2. **Calculate P/E ratios** – The price is divided by earnings per share.
+3. **Flag undervalued stocks** – Tickers with a P/E ratio below a configurable threshold are highlighted.
 
 ## Setup
 
-### Prerequisites
+1. Install the required dependencies:
+   ```bash
+   pip install requests
+   ```
+2. Edit `config.json` and provide your Alpha Vantage API key and desired P/E threshold:
+   ```json
+   {
+       "financial_api_key": "YOUR_FINANCIAL_API_KEY",
+       "pe_threshold": 15
+   }
+   ```
 
-- Python 3.7 or higher
-- Required Python packages (see `requirements.txt`)
+## Usage
 
-### Set up 
+Run the CLI and supply one or more ticker symbols. You can also specify a custom threshold with `--threshold`.
 
-1. Open Config,json file and input your grok api. 
-2. Run main.py file
-3. Input your objective  
+```bash
+python financial_cli.py AAPL MSFT --threshold 12
+```
+
+If no tickers are supplied on the command line, the tool will prompt for a comma-separated list.
+
+The script prints the calculated P/E for each ticker and lists those below the threshold.
+
+## License
+
+This project is licensed under the MIT License.

--- a/config.json
+++ b/config.json
@@ -3,5 +3,7 @@
     "orchestrator_model": "mixtral-8x7b-32768",
     "sub_agent_model": "mixtral-8x7b-32768",
     "refiner_model": "llama3-70b-8192",
-    "project_name": "AI_Driven_Application"
+    "project_name": "AI_Driven_Application",
+    "financial_api_key": "YOUR_FINANCIAL_API_KEY",
+    "pe_threshold": 15
 }

--- a/financial_cli.py
+++ b/financial_cli.py
@@ -1,0 +1,33 @@
+import argparse
+from pe_analysis import analyze_tickers, PE_THRESHOLD
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze P/E ratios for stock tickers")
+    parser.add_argument("tickers", nargs="*", help="List of stock tickers")
+    parser.add_argument("--threshold", type=float, default=None, help="Custom P/E threshold")
+    args = parser.parse_args()
+
+    if args.tickers:
+        tickers = [t.strip().upper() for t in args.tickers]
+    else:
+        user_input = input("Enter comma-separated tickers: ")
+        tickers = [t.strip().upper() for t in user_input.split(",") if t.strip()]
+
+    results, undervalued = analyze_tickers(tickers, args.threshold)
+    threshold = args.threshold if args.threshold is not None else PE_THRESHOLD
+
+    for res in results:
+        if res["pe"] is None:
+            print(f"{res['symbol']}: P/E unavailable")
+        else:
+            print(f"{res['symbol']}: P/E = {res['pe']:.2f}")
+
+    if undervalued:
+        print(f"\nUndervalued stocks (P/E < {threshold}): {', '.join(undervalued)}")
+    else:
+        print("\nNo stocks found below the threshold.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pe_analysis.py
+++ b/pe_analysis.py
@@ -1,0 +1,67 @@
+import requests
+from init import load_config
+
+CONFIG = load_config()
+API_KEY = CONFIG.get("financial_api_key")
+PE_THRESHOLD = CONFIG.get("pe_threshold", 15)
+
+ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
+
+
+def fetch_price(symbol):
+    """Fetch the latest closing price for a ticker."""
+    params = {
+        "function": "TIME_SERIES_DAILY_ADJUSTED",
+        "symbol": symbol,
+        "apikey": API_KEY,
+    }
+    resp = requests.get(ALPHA_VANTAGE_URL, params=params, timeout=10)
+    data = resp.json()
+    series = data.get("Time Series (Daily)")
+    if not series:
+        return None
+    latest_day = next(iter(series.values()))
+    try:
+        return float(latest_day["4. close"])
+    except (KeyError, ValueError, TypeError):
+        return None
+
+
+def fetch_eps(symbol):
+    """Fetch EPS data for a ticker."""
+    params = {
+        "function": "OVERVIEW",
+        "symbol": symbol,
+        "apikey": API_KEY,
+    }
+    resp = requests.get(ALPHA_VANTAGE_URL, params=params, timeout=10)
+    data = resp.json()
+    try:
+        return float(data.get("EPS", 0))
+    except (ValueError, TypeError):
+        return None
+
+
+def calculate_pe(symbol):
+    """Calculate P/E ratio for a single ticker."""
+    price = fetch_price(symbol)
+    eps = fetch_eps(symbol)
+    if price is None or eps in (None, 0):
+        return None
+    return price / eps
+
+
+def analyze_tickers(tickers, threshold=None):
+    """Analyze a list of tickers and flag those below the threshold."""
+    results = []
+    undervalued = []
+    threshold = threshold if threshold is not None else PE_THRESHOLD
+
+    for ticker in tickers:
+        ticker = ticker.upper()
+        pe = calculate_pe(ticker)
+        results.append({"symbol": ticker, "pe": pe})
+        if pe is not None and pe < threshold:
+            undervalued.append(ticker)
+
+    return results, undervalued


### PR DESCRIPTION
## Summary
- add a small module to query Alpha Vantage for price and EPS and compute P/E
- include a CLI script for running the analysis on tickers
- store API details and P/E threshold in `config.json`
- overhaul README to describe the new workflow

## Testing
- `python -m py_compile pe_analysis.py financial_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6840f40aaf5c8332b8c068c28809cf46